### PR TITLE
anno: remove local chunking comparison

### DIFF
--- a/crates/anno/Cargo.toml
+++ b/crates/anno/Cargo.toml
@@ -50,8 +50,7 @@ candle-transformers = { workspace = true, optional = true }
 safetensors = { workspace = true, optional = true }
 half = { workspace = true, optional = true }
 
-# Semantic text chunking (optional). Uses the `text-splitter` crate, which
-# is the de-facto standard Rust chunker (>1M downloads vs the local `slabs`).
+# Semantic text chunking (optional).
 text-splitter = { version = "0.28", optional = true }
 
 # Graph/KG export (optional). Adapters from extraction output to `lattix::KnowledgeGraph`.
@@ -166,4 +165,3 @@ required-features = ["gliner2-fastino-candle"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
-


### PR DESCRIPTION
## Summary
- remove a Cargo manifest comment comparing text-splitter against local slabs
- leave the historical 0.6.0 changelog entry alone

## Verification
- cargo metadata --no-deps --format-version 1
- git diff --check