### PR TITLE
anno: drop the slabs download-comparison comment

### DIFF
--- a/crates/anno/Cargo.toml
+++ b/crates/anno/Cargo.toml
@@ -50,8 +50,7 @@ candle-transformers = { workspace = true, optional = true }
 safetensors = { workspace = true, optional = true }
 half = { workspace = true, optional = true }
 
-# Semantic text chunking (optional). Uses the `text-splitter` crate, which
-# is the de-facto standard Rust chunker (>1M downloads vs the local `slabs`).
+# Semantic text chunking (optional).
 text-splitter = { version = "0.28", optional = true }
 
 # Graph/KG export (optional). Adapters from extraction output to `lattix::KnowledgeGraph`.
@@ -166,4 +165,3 @@ required-features = ["gliner2-fastino-candle"]
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
-


### PR DESCRIPTION
Removes a comment on the optional `text-splitter` dependency in `crates/anno/Cargo.toml` that compared it against the local `slabs` crate by download count. Cross-promoting a sibling crate by download numbers is workspace-internal framing that does not belong in a public crate's manifest. Comment-only, no dependency or code change.